### PR TITLE
Handling without newline input

### DIFF
--- a/examples/06without-newline.py
+++ b/examples/06without-newline.py
@@ -1,0 +1,1 @@
+print("hello")#

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,4 +1,4 @@
-default: 00 01 02 03 04 05
+default: 00 01 02 03 04 05 06
 
 OPTS ?= --logging=DEBUG
 
@@ -14,3 +14,5 @@ OPTS ?= --logging=DEBUG
 	pycomment ${OPTS} --inplace 04*.py
 05:
 	pycomment ${OPTS} --inplace 05*/main.py
+06:
+	pycomment ${OPTS} 06*.py > replaced.06,py

--- a/examples/replaced.06,py
+++ b/examples/replaced.06,py
@@ -1,0 +1,2 @@
+print("hello")## -- stdout --------------------
+# >> hello

--- a/examples/replaced.06,py
+++ b/examples/replaced.06,py
@@ -1,2 +1,3 @@
-print("hello")## -- stdout --------------------
+print("hello")#
+# -- stdout --------------------
 # >> hello

--- a/pycomment/emit.py
+++ b/pycomment/emit.py
@@ -48,6 +48,9 @@ def emit(
             i += 1
 
     if rest:
+        if not line.endswith("\n"):
+            print("", file=out)
+
         print(STDOUT_HEADER_MARKER, file=out)
         for line in rest:
             print("# >>", line, file=out)


### PR DESCRIPTION
This pull request introduces a new example script (`06without-newline.py`) and updates the `Makefile` and related files to support it. It also includes a minor enhancement to the `emit` function in `pycomment/emit.py` to handle cases where lines do not end with a newline. Below are the most important changes grouped by theme:

### New Example Script and Supporting Changes:
* Added a new example script `examples/06without-newline.py` that prints "hello" without a newline character at the end.
* Updated `examples/Makefile` to include the new example (`06`) in the default target and added a rule for processing `06*.py`. [[1]](diffhunk://#diff-ae8bb09b4bbb919309d4c8bb8ffc46e031bf63b7274502171a183a4dc1138f53L1-R1) [[2]](diffhunk://#diff-ae8bb09b4bbb919309d4c8bb8ffc46e031bf63b7274502171a183a4dc1138f53R17-R18)
* Added a new output file `examples/replaced.06,py` to capture the transformed output of the new example script. ([examples/replaced.06,pyR1-R3](diffhunk://#diff-53bcf06a234331a8532024d9fe531cf5ee5a892521cc40c3165e09a65016b499R1-R3))

### Enhancement to `emit` Function:
* Modified the `emit` function in `pycomment/emit.py` to insert an empty line before the standard output header if the last processed line does not end with a newline character. This ensures proper formatting of the output.